### PR TITLE
Update MoveItMock.cpp

### DIFF
--- a/test/MoveItMock.cpp
+++ b/test/MoveItMock.cpp
@@ -24,7 +24,7 @@ namespace moveit {
                                             const std::string& end_effector_link) {
       return true;
     }
-    MoveItErrorCode MoveGroupInterface::move() {
+    moveit::core::MoveItErrorCode MoveGroupInterface::move() {
       return MoveItErrorCode(moveit_msgs::MoveItErrorCodes::SUCCESS);
     }
     const std::vector<std::string>& MoveGroupInterface::getLinkNames() {


### PR DESCRIPTION
introduced explicit name space specification for the class MoveItErrorCode.